### PR TITLE
Dispatch events when a discussion becomes popular or is no longuer popular

### DIFF
--- a/src/Events/DiscussionBecamePopular.php
+++ b/src/Events/DiscussionBecamePopular.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ClarkWinkelmann\PopularDiscussionBadge\Events;
+
+/**
+ * This event will only be dispatched if the extension is using the scheduler mode.
+ */
+class DiscussionBecamePopular
+{
+    public $discussionId;
+
+    public function __construct($discussionId)
+    {
+        $this->discussionId = $discussionId;
+    }
+}

--- a/src/Events/DiscussionIsNoLongerPopular.php
+++ b/src/Events/DiscussionIsNoLongerPopular.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ClarkWinkelmann\PopularDiscussionBadge\Events;
+
+/**
+ * This event will only be dispatched if the extension is using the scheduler mode.
+ */
+class DiscussionIsNoLongerPopular
+{
+    public $discussionId;
+
+    public function __construct($discussionId)
+    {
+        $this->discussionId = $discussionId;
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Dispatch events when a discussion becomes popular or is no longuer popular

**Reviewers should focus on:**
Event gets fired correctly. Is there anything else to add in the properties of this event?

**Confirmed**

- [x] Backend changes: tests are green (run `composer test`).
